### PR TITLE
Add support for transparency

### DIFF
--- a/README
+++ b/README
@@ -35,7 +35,8 @@ handler:
         const char *fname,                  /* GIF file name */
         uint16_t width, uint16_t height,    /* frame size */
         uint8_t *palette, int depth,        /* color table */
-        int loop                            /* looping information */
+        int loop,                           /* looping information */
+        int transparent_index               /* index of color to make transparent */
     );
 
 The `palette` parameter  must point to an  array of color data. Each  entry is a
@@ -68,6 +69,10 @@ If the `loop` parameter is zero, the resulting GIF will loop forever. If it is a
 positive number, the  animation will  be played that number  of times. If `loop`
 is negative,  no looping  information is stored  in the GIF  file (for  most GIF
 viewers, this is equivalent to `loop` == 1, i.e., "play once").
+
+If the `transparent_index` parameter is != -1 it refers to an index in the
+`palette` to make transparent instead of using the color (it must be within the
+range of the `palette`). If it's -1, no color will be made transparent.
 
 The  ge_add_frame() function  reads  pixel  data from  a  buffer  and saves  the
 resulting frame to the file associated with the given ge_GIF handler:

--- a/example.c
+++ b/example.c
@@ -17,7 +17,8 @@ main()
             0x00, 0x00, 0xFF, /* 3 -> blue */
         },
         2,              /* palette depth == log2(# of colors) */
-        0               /* infinite loop */
+        0,              /* infinite loop */
+        -1              /* no transparent color */
     );
     /* draw some frames */
     for (i = 0; i < 4*6/3; i++) {

--- a/example_transparency.c
+++ b/example_transparency.c
@@ -4,17 +4,17 @@
 
 #define MIN(a,b) (((a)<(b))?(a):(b))
 
-static int frameindex = 0;
-void add_frame(ge_GIF* gif, uint16_t delay)
+
+static void
+add_frame(ge_GIF* gif, uint16_t delay)
 {
+	static int frameindex = 0;
     int height = 100;
 	int width  = 100;
 
 	printf("frame %03d: \n", frameindex++);
-	for(int i =0; i < height; i++)
-	{
-		for(int j =0; j < width; j++)
-		{
+	for(int i =0; i < height; i++) {
+		for(int j =0; j < width; j++) {
 			printf("%c", gif->frame[i*width + j] ? 'Z' : ' ');
 		}
 		printf("\n");
@@ -24,7 +24,8 @@ void add_frame(ge_GIF* gif, uint16_t delay)
 	ge_add_frame(gif, delay);
 }
 
-int main(int argc, char const *argv[])
+int
+main(int argc, char const *argv[])
 {
 	if (argc != 2) {
 		fprintf(stderr, "usage: %s <file.gif> <disposal>\n", argv[0]);
@@ -44,17 +45,16 @@ int main(int argc, char const *argv[])
 		0 /* transparent background */
 	);
 
-	for (size_t t = 0; t < 100; t++)
-	{
-		// clear the frame
+	for (size_t t = 0; t < 100; t++) {
+		/* clear the frame */
         memset(gif->frame, 0, (100*100));
 
-		// add the giant rectange to the frame on the left
+		/* add the giant rectange to the frame on the left */
 		for (i = 0; i < 100; i++)
 			for (j = 0; j < 100; j++)
 				gif->frame[i*100 + j] = i > 10 && i < 90 && j > 10 && j < 50;
 
-		// add the varying size right bar
+		/* add the varying size right bar */
 		for (i = 50; i > 0; i--)
 			for (j = 60; j < 65; j++)
 				gif->frame[i*100 + j] = i > MIN(t, 100 - t);

--- a/example_transparency.c
+++ b/example_transparency.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <string.h>
+#include "gifenc.h"
+
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
+static int frameindex = 0;
+void add_frame(ge_GIF* gif, uint16_t delay)
+{
+    int height = 100;
+	int width  = 100;
+
+	printf("frame %03d: \n", frameindex++);
+	for(int i =0; i < height; i++)
+	{
+		for(int j =0; j < width; j++)
+		{
+			printf("%c", gif->frame[i*width + j] ? 'Z' : ' ');
+		}
+		printf("\n");
+	}
+
+	printf("\n");
+	ge_add_frame(gif, delay);
+}
+
+int main(int argc, char const *argv[])
+{
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s <file.gif> <disposal>\n", argv[0]);
+		return 1;
+	}
+
+	size_t i, j;
+	ge_GIF* gif;
+	gif = ge_new_gif(
+		argv[1], 100, 100,
+		(uint8_t []) { /* R, G, B */
+			0xff, 0xff, 0xff,
+			0xda, 0x09, 0xff,
+		},
+		1,
+		0, /* infinite loop */
+		0 /* transparent background */
+	);
+
+	for (size_t t = 0; t < 100; t++)
+	{
+		// clear the frame
+        memset(gif->frame, 0, (100*100));
+
+		// add the giant rectange to the frame on the left
+		for (i = 0; i < 100; i++)
+			for (j = 0; j < 100; j++)
+				gif->frame[i*100 + j] = i > 10 && i < 90 && j > 10 && j < 50;
+
+		// add the varying size right bar
+		for (i = 50; i > 0; i--)
+			for (j = 60; j < 65; j++)
+				gif->frame[i*100 + j] = i > MIN(t, 100 - t);
+		add_frame(gif, 5);		
+	}
+
+	ge_close_gif(gif);
+	return 0;
+}

--- a/gifenc.c
+++ b/gifenc.c
@@ -289,18 +289,19 @@ add_graphics_control_extension(ge_GIF *gif, const uint16_t d, const DisposalMeth
 {
     uint8_t out[4] = {'!', 0xF9, 0x04, dm};
     if(gif->transparent_index != -1) {
-        out[3] |= 0x1; // transparent color flag
+        out[3] |= 0x1; /* transparent color flag */
     }
     write(gif->fd, out, sizeof(out));
     write_num(gif->fd, d);
     out[0] = 0;
     out[1] = 0;
-    if(gif->transparent_index != -1)
+    if(gif->transparent_index != -1) {
         out[0] = gif->transparent_index;
+    }
     write(gif->fd, out, 2);
 }
 
-void
+static void
 add_frame_with_transparency(ge_GIF *gif, const bool has_new_frame)
 {
     gif->has_unencoded_frame = false;
@@ -309,38 +310,30 @@ add_frame_with_transparency(ge_GIF *gif, const bool has_new_frame)
     uint16_t h = gif->unencoded_h;
     uint16_t x = gif->unencoded_x;
     uint16_t y = gif->unencoded_y;
-    if(has_new_frame)
-    {
+    if(has_new_frame) {
         /* if the new frame has any new transparent pixels (not already transparent) RTB is required */
-        for(int i = 0; i < gif->h; i++)
-        {
-            for(int j = 0; j < gif->w; j++)
-            {
-                if((gif->frame[i*gif->w + j] == gif->transparent_index) && (gif->back[i*gif->w+j] != gif->transparent_index))
-                {
+        for(int i = 0; i < gif->h; i++) {
+            for(int j = 0; j < gif->w; j++) {
+                if((gif->frame[i*gif->w + j] == gif->transparent_index) && (gif->back[i*gif->w+j] != gif->transparent_index)) {
                     dm = DM_RTB;
                     /* adjust the BB so the pixel will be cleared on RTB*/
-                    if(i < y)
-                    {
+                    if(i < y) {
                         const uint16_t delta = y-i;
                         y = i;
                         h += delta;
                     }
 
-                    if(j < x)
-                    {
+                    if(j < x) {
                         const uint16_t delta = x-j;
                         x = j;
                         w += delta;
                     }
 
-                    if(i >= (y+gif->h))
-                    {
+                    if(i >= (y+gif->h)) {
                         h += (i-(y+gif->h)+1);
                     }
 
-                    if(j >= (x+gif->w))
-                    {
+                    if(j >= (x+gif->w)) {
                         w += (j-(x+gif->w)+1);
                     }
                 }
@@ -351,13 +344,10 @@ add_frame_with_transparency(ge_GIF *gif, const bool has_new_frame)
     add_graphics_control_extension(gif, gif->unencoded_delay, dm);
     put_image(gif, gif->back, w, h, x, y);
 
-    if(dm == DM_RTB)
-    {
+    if(dm == DM_RTB) {
         /* RTB our internal model, used by get_bbox*/
-        for(int i = y; i < (y+h); i++)
-        {
-            for(int j = x; j < (x+w); j++)
-            {
+        for(int i = y; i < (y+h); i++) {
+            for(int j = x; j < (x+w); j++) {
                 gif->back[i*gif->w + j] = gif->transparent_index;
             }
         }
@@ -387,15 +377,12 @@ ge_add_frame(ge_GIF *gif, uint16_t delay)
     }
 
     /* encode the frame now if transparency isn't used at all*/
-    if(gif->transparent_index == -1)
-    {
+    if(gif->transparent_index == -1) {
         if(delay) {
             add_graphics_control_extension(gif, delay, DM_DND);
         }
         put_image(gif, gif->frame, w, h, x, y);
-    }
-    else
-    {
+    } else {
         gif->has_unencoded_frame = true;
         gif->unencoded_w = w;
         gif->unencoded_h = h;

--- a/gifenc.c
+++ b/gifenc.c
@@ -280,8 +280,9 @@ static void
 add_graphics_control_extension(ge_GIF *gif, uint16_t d)
 {
     uint8_t out[4] = {'!', 0xF9, 0x04, 0x04};
-    if(gif->transparent_index != -1)
-        out[3] |= 0x1;
+    if(gif->transparent_index != -1) {
+        out[3] = 0x8 | 0x1; // RTB and transparent color flag
+    }
     write(gif->fd, out, sizeof(out));
     write_num(gif->fd, d);
     out[0] = 0;
@@ -299,7 +300,7 @@ ge_add_frame(ge_GIF *gif, uint16_t delay)
 
     if (delay || (gif->transparent_index != -1))
         add_graphics_control_extension(gif, delay);
-    if (gif->nframes == 0) {
+    if ((gif->nframes == 0) || (gif->transparent_index != -1)) {
         w = gif->w;
         h = gif->h;
         x = y = 0;

--- a/gifenc.h
+++ b/gifenc.h
@@ -2,6 +2,7 @@
 #define GIFENC_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,6 +17,13 @@ typedef struct ge_GIF {
     int nframes;
     uint8_t *frame, *back;
     uint32_t partial;
+
+    /* transparency only */
+    bool has_unencoded_frame;
+    uint16_t unencoded_delay;
+    uint16_t unencoded_x,unencoded_y, unencoded_w, unencoded_h;
+
+
     uint8_t buffer[0xFF];
 } ge_GIF;
 

--- a/gifenc.h
+++ b/gifenc.h
@@ -10,6 +10,7 @@ extern "C" {
 typedef struct ge_GIF {
     uint16_t w, h;
     int depth;
+    int transparent_index;
     int fd;
     int offset;
     int nframes;
@@ -20,7 +21,7 @@ typedef struct ge_GIF {
 
 ge_GIF *ge_new_gif(
     const char *fname, uint16_t width, uint16_t height,
-    uint8_t *palette, int depth, int loop
+    uint8_t *palette, int depth, int loop, int transparent_index
 );
 void ge_add_frame(ge_GIF *gif, uint16_t delay);
 void ge_close_gif(ge_GIF* gif);


### PR DESCRIPTION
Adds a `transparent_index` parameter to `ge_new_gif` that controls what color in the palette to make transparent if any. Pass -1 if no transparency is desired.

While transparency is implemented using the Graphics Control Extension block (already used for delay on every frame). For color consistency because there isn't a frame-local palette it was added to  `ge_new_gif` instead of `ge_add_frame`.