### PR TITLE
Fix transparency when delay is set to 0.

### DIFF
--- a/gifenc.c
+++ b/gifenc.c
@@ -280,7 +280,7 @@ get_bbox(ge_GIF *gif, uint16_t *w, uint16_t *h, uint16_t *x, uint16_t *y)
 }
 
 static void
-set_delay(ge_GIF *gif, uint16_t d)
+add_graphics_control_extension(ge_GIF *gif, uint16_t d)
 {
     uint8_t flags = ((gif->bgindex >= 0 ? 2 : 1) << 2) + 1;
     write(gif->fd, (uint8_t []) {'!', 0xF9, 0x04, flags}, 4);
@@ -294,8 +294,8 @@ ge_add_frame(ge_GIF *gif, uint16_t delay)
     uint16_t w, h, x, y;
     uint8_t *tmp;
 
-    if (delay)
-        set_delay(gif, delay);
+    if (delay || (gif->bgindex >= 0))
+        add_graphics_control_extension(gif, delay);
     if (gif->nframes == 0) {
         w = gif->w;
         h = gif->h;


### PR DESCRIPTION
The graphics control extension extension is needed to encode a delay or anytime a frame has any transparency. For simplicity, always encode it when `gif->bgindex >= 0`.

This fixes gif frames with transparency when delay is set to 0. 

Before:
![out orig](https://user-images.githubusercontent.com/2080147/129920882-b43550e7-b803-4d5f-b8f4-a06900c75152.gif)

After:
![out](https://user-images.githubusercontent.com/2080147/129920926-289be991-7d75-43da-8355-890864513d64.gif)


