### PR TITLE
Change creat()/write()/close() to fopen()/fwrite()/fclose()

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,7 @@ Limitations
 Documentation
 -------------
 
-There   are  only   three  functions   declared  in   "gifenc.h":  ge_new_gif(),
+There   are  only   four  functions   declared  in   "gifenc.h":  ge_new_gif(),
 ge_add_frame() and ge_close_gif().
 
 The  ge_new_gif() function  receives GIF  global  options and  returns a  ge_GIF
@@ -73,6 +73,21 @@ If the `loop` parameter is zero, the resulting GIF will loop forever. If it is a
 positive number, the  animation will  be played that number  of times. If `loop`
 is negative,  no looping  information is stored  in the GIF  file (for  most GIF
 viewers, this is equivalent to `loop` == 1, i.e., "play once").
+
+There is another function called ge_new_gif_filestream, which takes a FILE* 
+instead of a string for the file name, in case you want to write the output to 
+something that isn't an actual file (e.g. an fmemopen buffer). The behaviour is 
+otherwise identical to that of ge_new_gif.
+
+    ge_GIF *ge_new_gif_filestream(
+        const char *fname,                  /* GIF file name */
+        uint16_t width, uint16_t height,    /* frame size */
+        uint8_t *palette, int depth,        /* color table */
+        int bgindex,                        /* transparent color */
+        int loop                            /* looping information */
+    );
+
+
 
 The  ge_add_frame() function  reads  pixel  data from  a  buffer  and saves  the
 resulting frame to the file associated with the given ge_GIF handler:
@@ -121,9 +136,9 @@ The function  ge_close_gif() finishes writting  GIF data to the  file associated
 with the  given ge_GIF handler and  does memory clean-up. This  function must be
 called once after all desired frames have been added, in order to correctly save
 the GIF  file. After calling  this function, the  ge_GIF handler cannot  be used
-anymore.
+anymore. ge_close_gif() returns the total size in bytes of the written gif file.
 
-    void ge_close_gif(ge_GIF* gif);
+    size_t ge_close_gif(ge_GIF* gif);
 
 (*) The  encoder keeps two frame  buffers internally, in order  to implement the
 size  optimization. The  address of  `gif->frame` alternates  between those  two

--- a/gifenc.c
+++ b/gifenc.c
@@ -73,9 +73,19 @@ do { \
 
 static void put_loop(ge_GIF *gif, uint16_t loop);
 
+
 ge_GIF *
 ge_new_gif(
     const char *fname, uint16_t width, uint16_t height,
+    uint8_t *palette, int depth, int bgindex, int loop
+    )
+{
+    return ge_new_gif_filestream(fopen(fname, "wb"), width, height, palette, depth, bgindex, loop);
+}
+
+ge_GIF *
+ge_new_gif_filestream(
+    FILE * file, uint16_t width, uint16_t height,
     uint8_t *palette, int depth, int bgindex, int loop
 )
 {
@@ -89,7 +99,7 @@ ge_new_gif(
     gif->bgindex = bgindex;
     gif->frame = (uint8_t *) &gif[1];
     gif->back = &gif->frame[width*height];
-    gif->file = fopen(fname, "wb");
+    gif->file = file;
     if (!gif->file)
         goto no_fd;
     fwrite("GIF89a", 1, 6, gif->file);
@@ -299,10 +309,12 @@ ge_add_frame(ge_GIF *gif, uint16_t delay)
     }
 }
 
-void
+size_t
 ge_close_gif(ge_GIF* gif)
 {
     fwrite(";", 1, 1, gif->file);
+    size_t sz = ftell(gif->file);
     fclose(gif->file);
     free(gif);
+    return sz;
 }

--- a/gifenc.c
+++ b/gifenc.c
@@ -3,17 +3,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
 
 /* helper to write a little-endian 16-bit number portably */
-#define write_num(fd, n) write((fd), (uint8_t []) {(n) & 0xFF, (n) >> 8}, 2)
+#define fwrite_num(file, n) fwrite((uint8_t []) {(n) & 0xFF, (n) >> 8}, 1, 2, (file))
 
 static uint8_t vga[0x30] = {
     0x00, 0x00, 0x00,
@@ -70,9 +62,9 @@ del_trie(Node *root, int degree)
     free(root);
 }
 
-#define write_and_store(s, dst, fd, src, n) \
+#define fwrite_and_store(s, dst, file, src, n) \
 do { \
-    write(fd, src, n); \
+    fwrite(src, 1, n, file); \
     if (s) { \
         memcpy(dst, src, n); \
         dst += n; \
@@ -97,19 +89,12 @@ ge_new_gif(
     gif->bgindex = bgindex;
     gif->frame = (uint8_t *) &gif[1];
     gif->back = &gif->frame[width*height];
-#ifdef _WIN32
-    gif->fd = creat(fname, S_IWRITE);
-#else
-    gif->fd = creat(fname, 0666);
-#endif
-    if (gif->fd == -1)
+    gif->file = fopen(fname, "wb");
+    if (!gif->file)
         goto no_fd;
-#ifdef _WIN32
-    setmode(gif->fd, O_BINARY);
-#endif
-    write(gif->fd, "GIF89a", 6);
-    write_num(gif->fd, width);
-    write_num(gif->fd, height);
+    fwrite("GIF89a", 1, 6, gif->file);
+    fwrite_num(gif->file, width);
+    fwrite_num(gif->file, height);
     store_gct = custom_gct = 0;
     if (palette) {
         if (depth < 0)
@@ -120,18 +105,18 @@ ge_new_gif(
     if (depth < 0)
         depth = -depth;
     gif->depth = depth > 1 ? depth : 2;
-    write(gif->fd, (uint8_t []) {0xF0 | (depth-1), (uint8_t) bgindex, 0x00}, 3);
+    fwrite((uint8_t []) {0xF0 | (depth-1), (uint8_t) bgindex, 0x00}, 1, 3, gif->file);
     if (custom_gct) {
-        write(gif->fd, palette, 3 << depth);
+        fwrite(palette, 1, 3 << depth, gif->file);
     } else if (depth <= 4) {
-        write_and_store(store_gct, palette, gif->fd, vga, 3 << depth);
+        fwrite_and_store(store_gct, palette, gif->file, vga, 3 << depth);
     } else {
-        write_and_store(store_gct, palette, gif->fd, vga, sizeof(vga));
+        fwrite_and_store(store_gct, palette, gif->file, vga, sizeof(vga));
         i = 0x10;
         for (r = 0; r < 6; r++) {
             for (g = 0; g < 6; g++) {
                 for (b = 0; b < 6; b++) {
-                    write_and_store(store_gct, palette, gif->fd,
+                    fwrite_and_store(store_gct, palette, gif->file,
                       ((uint8_t []) {r*51, g*51, b*51}), 3
                     );
                     if (++i == 1 << depth)
@@ -141,7 +126,7 @@ ge_new_gif(
         }
         for (i = 1; i <= 24; i++) {
             v = i * 0xFF / 25;
-            write_and_store(store_gct, palette, gif->fd,
+            fwrite_and_store(store_gct, palette, gif->file,
               ((uint8_t []) {v, v, v}), 3
             );
         }
@@ -159,11 +144,11 @@ no_gif:
 static void
 put_loop(ge_GIF *gif, uint16_t loop)
 {
-    write(gif->fd, (uint8_t []) {'!', 0xFF, 0x0B}, 3);
-    write(gif->fd, "NETSCAPE2.0", 11);
-    write(gif->fd, (uint8_t []) {0x03, 0x01}, 2);
-    write_num(gif->fd, loop);
-    write(gif->fd, "\0", 1);
+    fwrite((uint8_t []) {'!', 0xFF, 0x0B}, 1, 3, gif->file);
+    fwrite("NETSCAPE2.0", 1, 11, gif->file);
+    fwrite((uint8_t []) {0x03, 0x01}, 1, 2, gif->file);
+    fwrite_num(gif->file, loop);
+    fwrite("\0", 1, 1, gif->file);
 }
 
 /* Add packed key to buffer, updating offset and partial.
@@ -180,8 +165,8 @@ put_key(ge_GIF *gif, uint16_t key, int key_size)
     while (bits_to_write >= 8) {
         gif->buffer[byte_offset++] = gif->partial & 0xFF;
         if (byte_offset == 0xFF) {
-            write(gif->fd, "\xFF", 1);
-            write(gif->fd, gif->buffer, 0xFF);
+            fwrite("\xFF", 1, 1, gif->file);
+            fwrite(gif->buffer, 1, 0xFF, gif->file);
             byte_offset = 0;
         }
         gif->partial >>= 8;
@@ -198,10 +183,10 @@ end_key(ge_GIF *gif)
     if (gif->offset % 8)
         gif->buffer[byte_offset++] = gif->partial & 0xFF;
     if (byte_offset) {
-        write(gif->fd, (uint8_t []) {byte_offset}, 1);
-        write(gif->fd, gif->buffer, byte_offset);
+        fwrite((uint8_t []) {byte_offset}, 1, 1, gif->file);
+        fwrite(gif->buffer, 1, byte_offset, gif->file);
     }
-    write(gif->fd, "\0", 1);
+    fwrite("\0", 1, 1, gif->file);
     gif->offset = gif->partial = 0;
 }
 
@@ -212,12 +197,12 @@ put_image(ge_GIF *gif, uint16_t w, uint16_t h, uint16_t x, uint16_t y)
     Node *node, *child, *root;
     int degree = 1 << gif->depth;
 
-    write(gif->fd, ",", 1);
-    write_num(gif->fd, x);
-    write_num(gif->fd, y);
-    write_num(gif->fd, w);
-    write_num(gif->fd, h);
-    write(gif->fd, (uint8_t []) {0x00, gif->depth}, 2);
+    fwrite(",", 1, 1, gif->file);
+    fwrite_num(gif->file, x);
+    fwrite_num(gif->file, y);
+    fwrite_num(gif->file, w);
+    fwrite_num(gif->file, h);
+    fwrite((uint8_t []) {0x00, gif->depth}, 1, 2, gif->file);
     root = node = new_trie(degree, &nkeys);
     key_size = gif->depth + 1;
     put_key(gif, degree, key_size); /* clear code */
@@ -283,9 +268,9 @@ static void
 add_graphics_control_extension(ge_GIF *gif, uint16_t d)
 {
     uint8_t flags = ((gif->bgindex >= 0 ? 2 : 1) << 2) + 1;
-    write(gif->fd, (uint8_t []) {'!', 0xF9, 0x04, flags}, 4);
-    write_num(gif->fd, d);
-    write(gif->fd, (uint8_t []) {(uint8_t) gif->bgindex, 0x00}, 2);
+    fwrite((uint8_t []) {'!', 0xF9, 0x04, flags}, 1, 4, gif->file);
+    fwrite_num(gif->file, d);
+    fwrite((uint8_t []) {(uint8_t) gif->bgindex, 0x00}, 1, 2, gif->file);
 }
 
 void
@@ -317,7 +302,7 @@ ge_add_frame(ge_GIF *gif, uint16_t delay)
 void
 ge_close_gif(ge_GIF* gif)
 {
-    write(gif->fd, ";", 1);
-    close(gif->fd);
+    fwrite(";", 1, 1, gif->file);
+    fclose(gif->file);
     free(gif);
 }

--- a/gifenc.h
+++ b/gifenc.h
@@ -24,8 +24,14 @@ ge_GIF *ge_new_gif(
     const char *fname, uint16_t width, uint16_t height,
     uint8_t *palette, int depth, int bgindex, int loop
 );
+
+ge_GIF *ge_new_gif_filestream(
+    FILE * f, uint16_t width, uint16_t height,
+    uint8_t *palette, int depth, int bgindex, int loop
+);
+
 void ge_add_frame(ge_GIF *gif, uint16_t delay);
-void ge_close_gif(ge_GIF* gif);
+size_t ge_close_gif(ge_GIF* gif);
 
 #ifdef __cplusplus
 }

--- a/gifenc.h
+++ b/gifenc.h
@@ -2,6 +2,7 @@
 #define GIFENC_H
 
 #include <stdint.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,7 +12,7 @@ typedef struct ge_GIF {
     uint16_t w, h;
     int depth;
     int bgindex;
-    int fd;
+    FILE* file;
     int offset;
     int nframes;
     uint8_t *frame, *back;


### PR DESCRIPTION
You may not be interested in these changes, which is fine of course, but I implemented these for my own purposes and I figured that I would offer them back. 

This PR changes 3 things:

- creat()/write()/close() was replaced with fopen()/fwrite()/fclose(). My reason for implementing this was in case the user wanted to write to a buffer created with `fmemopen` instead of to an actual file (I have such a use case).

- A new function was added, `ge_new_gif_filestream` that accepts a `FILE*` instead of a filename.

- The function `ge_close_gif` now returns the total length of the written gif file as a `size_t` 